### PR TITLE
Fix not-wanted underline of links in language menu

### DIFF
--- a/Resources/Private/Scss/Sections/_language-menu.scss
+++ b/Resources/Private/Scss/Sections/_language-menu.scss
@@ -7,6 +7,7 @@
 	.language-menu_switch {
 		margin-left: 1em;
 		filter: grayscale(100%);
+		text-decoration: none;
 
 		&:hover {
 			filter: grayscale(0%);

--- a/Resources/Private/Scss/Sections/_subject-search.scss
+++ b/Resources/Private/Scss/Sections/_subject-search.scss
@@ -17,6 +17,10 @@
 			&.open,
 			&.close {
 
+				a {
+					color: $text-color;
+				}
+
 				&:after {
 					top: .5em;
 					right: .3em;
@@ -25,10 +29,10 @@
 
 			a {
 				border-bottom: 1px dotted $text-color;
-				padding: 7px 12px 7px 7px;
-				color: $text-color;
+				padding: .5em;
+				color: $link-color;
 				font-weight: normal;
-				font-size: 100%;
+				text-decoration: none;
 			}
 		}
 

--- a/Resources/Public/Css/screen.css
+++ b/Resources/Public/Css/screen.css
@@ -2268,7 +2268,8 @@ fieldset {
   .language-menu .language-menu_switch {
     margin-left: 1em;
     -webkit-filter: grayscale(100%);
-            filter: grayscale(100%); }
+            filter: grayscale(100%);
+    text-decoration: none; }
     .language-menu .language-menu_switch:hover {
       -webkit-filter: grayscale(0%);
               filter: grayscale(0%); }
@@ -2580,15 +2581,17 @@ fieldset {
   border: 0 none; }
   .content-container .gokContainer.column li.selected, .content-container .gokContainer.column .tx_find .facet-type-Tabs ol .selected.facetActive, .tx_find .facet-type-Tabs ol .content-container .gokContainer.column .selected.facetActive {
     background: #b5c5e6; }
+  .content-container .gokContainer.column li.open a, .content-container .gokContainer.column .tx_find .facet-type-Tabs ol .open.facetActive a, .tx_find .facet-type-Tabs ol .content-container .gokContainer.column .open.facetActive a, .content-container .gokContainer.column li.close a, .content-container .gokContainer.column .tx_find .facet-type-Tabs ol .close.facetActive a, .tx_find .facet-type-Tabs ol .content-container .gokContainer.column .close.facetActive a {
+    color: #000; }
   .content-container .gokContainer.column li.open:after, .content-container .gokContainer.column .tx_find .facet-type-Tabs ol .open.facetActive:after, .tx_find .facet-type-Tabs ol .content-container .gokContainer.column .open.facetActive:after, .content-container .gokContainer.column li.close:after, .content-container .gokContainer.column .tx_find .facet-type-Tabs ol .close.facetActive:after, .tx_find .facet-type-Tabs ol .content-container .gokContainer.column .close.facetActive:after {
     top: .5em;
     right: .3em; }
   .content-container .gokContainer.column li a, .content-container .gokContainer.column .tx_find .facet-type-Tabs ol .facetActive a, .tx_find .facet-type-Tabs ol .content-container .gokContainer.column .facetActive a {
     border-bottom: 1px dotted #000;
-    padding: 7px 12px 7px 7px;
-    color: #000;
+    padding: .5em;
+    color: #192d57;
     font-weight: normal;
-    font-size: 100%; }
+    text-decoration: none; }
 .content-container .gokContainer.column .GOKID {
   font-weight: bold; }
 


### PR DESCRIPTION
This removes an underline in the subject-menu and language-menu parts
where this decoration is not useful.

Resolves: FM-103
