### PR TITLE
Fix main navigation markup

### DIFF
--- a/Configuration/TypoScript/Elements/30_mainMenu.ts
+++ b/Configuration/TypoScript/Elements/30_mainMenu.ts
@@ -23,7 +23,7 @@ lib.mainmenu {
 
 		SPC = 1
 		SPC {
-			allWrap = <li class="trenner">&nbsp;</li>
+			allWrap = <li class="trenner main-navigation_element">&nbsp;</li>
 			doNotShowLink = 1
 		}
 	}


### PR DESCRIPTION
This fixes the missing separator line in the main menu when there is
a spacer involved.

Resolves: FM-130
